### PR TITLE
feat: node workload prediction.

### DIFF
--- a/services/orchestra/workload_prediction/config/measurement_conf.yaml
+++ b/services/orchestra/workload_prediction/config/measurement_conf.yaml
@@ -1,14 +1,12 @@
-container_cpu:
-  name: container_cpu
+cpu:
+  name: cpu
   measurement: "cpu"
   diff: false
-  tag_keys: [cluster, namespace, pod_name]
   fields: [{name: value, data_type: ""}]
 
 
-container_mem:
-  name: container_mem
+mem:
+  name: mem
   measurement: "memory"
   diff: false
-  tag_keys: [cluster, namespace, pod_name]
   fields: [{name: value, data_type: ""}]


### PR DESCRIPTION
The simplest one to implement node workload prediction.

- Add condition to distinguish different predicted unit,
  i.e. pod or node prediction.
- Implement functions to deal with data format transformation for
  querying node workload & writing node prediction results.

Github issue #22 